### PR TITLE
Add VAGRANT_DEFAULT_PROVIDER to avoid provider error

### DIFF
--- a/chapter2/vagrant/Vagrantfile
+++ b/chapter2/vagrant/Vagrantfile
@@ -1,5 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 
 _post_up = <<-SCRIPT
 #!/bin/sh -x

--- a/chapter3/vagrant/ansible/Vagrantfile
+++ b/chapter3/vagrant/ansible/Vagrantfile
@@ -1,5 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 
 _post_up = <<-SCRIPT
 #!/bin/sh -x

--- a/chapter3/vagrant/ansible_fedora/Vagrantfile
+++ b/chapter3/vagrant/ansible_fedora/Vagrantfile
@@ -1,5 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 
 _post_up = <<-SCRIPT
 #!/bin/sh -x

--- a/chapter3/vagrant/awx/Vagrantfile
+++ b/chapter3/vagrant/awx/Vagrantfile
@@ -1,5 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 
 _post_up = <<-SCRIPT
 #!/bin/sh -x

--- a/chapter3/vagrant/awx_fedora/Vagrantfile
+++ b/chapter3/vagrant/awx_fedora/Vagrantfile
@@ -1,5 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 
 _post_up = <<-SCRIPT
 #!/bin/sh -x

--- a/chapter3/vagrant/linux_nodes/Vagrantfile
+++ b/chapter3/vagrant/linux_nodes/Vagrantfile
@@ -1,5 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 
 _post_up = <<-SCRIPT
 sudo subscription-manager register \

--- a/chapter3/vagrant/linux_nodes_fedora/Vagrantfile
+++ b/chapter3/vagrant/linux_nodes_fedora/Vagrantfile
@@ -1,5 +1,6 @@
-6# -*- mode: ruby -*-
+# -*- mode: ruby -*-
 # vi: set ft=ruby :
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 
 _post_up = <<-SCRIPT
 #!/bin/sh -x

--- a/chapter4/container/vagrant/Vagrantfile
+++ b/chapter4/container/vagrant/Vagrantfile
@@ -1,5 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 
 _post_up = <<-SCRIPT
 #!/bin/sh -x

--- a/chapter4/linux/vagrant/Vagrantfile
+++ b/chapter4/linux/vagrant/Vagrantfile
@@ -1,5 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 
 _post_up_managed_node = <<-SCRIPT
 for nic in "eth0" "eth1"

--- a/chapter4/network/vagrant/Vagrantfile
+++ b/chapter4/network/vagrant/Vagrantfile
@@ -1,5 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 
 # Before vagrant up with this Vagrantfile,
 # You may need to install 'vagrant-vyos' like following:

--- a/chapter5/vagrant/ansible_fedora/Vagrantfile
+++ b/chapter5/vagrant/ansible_fedora/Vagrantfile
@@ -1,5 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 
 _post_up = <<-SCRIPT
 #!/bin/sh -x

--- a/chapter7/vagrant/awx_fedora/Vagrantfile
+++ b/chapter7/vagrant/awx_fedora/Vagrantfile
@@ -1,5 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 
 _post_up = <<-SCRIPT
 #!/bin/sh -x


### PR DESCRIPTION
This will add `ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'` in Vagrantfile to set default provider without `vagrant up --provider=PROVIDER` option.